### PR TITLE
Hyper-parameter optimization 2.0

### DIFF
--- a/experiments/circle/params.json
+++ b/experiments/circle/params.json
@@ -1,22 +1,29 @@
 {
-  "input_size": 400,
-  "hidden_size": 10000,
-  "output_size": 400,
-
-  "reservoir_representation": "sparse",
-  "spectral_radius" : 2.0,
-  "in_weight_init" : 1.00,
-  "in_bias_init": 1.00,
-  "density": 1e-4,
-
-  "train_length": 800,
-  "pred_length": 300,
-  "transient_length": 100,
-  "train_method": "pinv",
-  "tikhonov_beta": 5,
-
-  "sigma": 0.2,
-  "xsize": [20,20],
-  "ksize": [10,10],
-  "domain": "pixels"
+    "input_size": 400,
+    "hidden_size": 10000,
+    "output_size": 400,
+    "reservoir_representation": "sparse",
+    "spectral_radius": 2.0,
+    "in_weight_init": 1.0,
+    "in_bias_init": 1.0,
+    "density": 0.0001,
+    "train_length": 800,
+    "pred_length": 300,
+    "transient_length": 100,
+    "train_method": "pinv",
+    "tikhonov_beta": 5,
+    "sigma": 0.2,
+    "xsize": [
+        20,
+        20
+    ],
+    "ksize": [
+        10,
+        10
+    ],
+    "domain": "pixels",
+    "size": [
+        20,
+        20
+    ]
 }

--- a/experiments/circle/run.py
+++ b/experiments/circle/run.py
@@ -51,7 +51,7 @@ model = ESN(params)
 
 logger.info("Training + predicting ...")
 model, outputs, pred_labels, _ = torsk.train_predict_esn(
-    model, loader, params, outfile="results.nc", modelfile="model.pth")
+    model, loader, params, outdir=".")
 
 logger.info("Visualizing results ...")
 

--- a/experiments/mackey/hpopt_params.json
+++ b/experiments/mackey/hpopt_params.json
@@ -6,7 +6,7 @@
   "reservoir_representation": "dense",
   "spectral_radius" : 1.39,
   "in_weight_init" : 0.67,
-  "in_bias_init": 0.41,
+  "in_bias_init": 0.0,
   "density": 0.03,
 
   "train_length": 2200,

--- a/experiments/mackey/params.json
+++ b/experiments/mackey/params.json
@@ -1,18 +1,15 @@
 {
-  "input_size": 1,
-  "hidden_size": 1000,
-  "output_size": 1,
-
-  "reservoir_representation": "dense",
-  "spectral_radius" : 1.39,
-  "in_weight_init" : 0.67,
-  "in_bias_init": 0.41,
-  "density": 0.03,
-
-  "train_length": 2200,
-  "pred_length": 500,
-  "transient_length": 200,
-  
-  "train_method": "tikhonov",
-  "tikhonov_beta": 2.0
+    "input_size": 1,
+    "hidden_size": 1000,
+    "output_size": 1,
+    "reservoir_representation": "dense",
+    "spectral_radius": 1.39,
+    "in_weight_init": 0.67,
+    "in_bias_init": 0.41,
+    "density": 0.03,
+    "train_length": 2200,
+    "pred_length": 500,
+    "transient_length": 200,
+    "train_method": "tikhonov",
+    "tikhonov_beta": 2.0
 }

--- a/experiments/mackey/run.py
+++ b/experiments/mackey/run.py
@@ -30,8 +30,7 @@ predictions, labels = [], []
 for i in tqdm(range(20)):
 
     model, outputs, pred_labels, _ = torsk.train_predict_esn(
-        model=model, loader=loader, params=params,
-        outfile="results.nc", modelfile="model.pth")
+        model=model, loader=loader, params=params, outdir=".")
 
     predictions.append(outputs.squeeze().numpy())
     labels.append(pred_labels.squeeze().numpy())

--- a/experiments/ocean/run.py
+++ b/experiments/ocean/run.py
@@ -8,7 +8,7 @@ from torchvision import transforms
 import torsk
 from torsk.models import ESN
 from torsk.data import NetcdfDataset, SeqDataLoader
-from torsk.visualize import animate_double_imshow
+from torsk.visualize import animate_double_imshow, write_video
 
 
 logger = logging.getLogger(__file__)

--- a/experiments/sine/hpopt.py
+++ b/experiments/sine/hpopt.py
@@ -12,27 +12,27 @@ from torsk.data import SineDataset, SeqDataLoader
 from torsk.hpopt import esn_tikhonov_fitnessfunc
 
 
-logging.basicConfig(level="INFO")
+logging.basicConfig(level="WARNING")
 
 
 opt_steps = 50
 tik_steps = 20
 tik_start = -5
 tik_stop = 2
-tikhonov_betas = np.logspace(tik_start, tik_stop, tik_steps)
+tik_betas = np.logspace(tik_start, tik_stop, tik_steps)
+level2 = [{"tikhonov_beta":beta, "train_method":"tikhonov"} for beta in tik_betas]
+level2.append({"tikhonov_beta":None, "train_method":"pinv"})
 
-output_dir = pathlib.Path("hpopt")
+output_dir = pathlib.Path("hpopt_output")
 
 dimensions = [
     Real(low=0.5, high=2.0, name="spectral_radius"),
     Real(low=0.0, high=2.0, name="in_weight_init"),
-    Real(low=0.0, high=2.0, name="in_bias_init"),
 ]
 
 starting_params = [
     1.0,    # esn_spectral_radius
-    0.01,    # in_weight_init
-    0.01,    # in_bias_init
+    0.01,   # in_weight_init
 ]
 
 params = torsk.Params("hpopt_params.json")
@@ -41,9 +41,9 @@ dataset = SineDataset(
     pred_length=params.pred_length)
 loader = iter(SeqDataLoader(dataset, batch_size=1, shuffle=True))
 
-fitness = esn_tikhonov_fitnessfunc(loader, params, dimensions, tikhonov_betas)
+fitness = esn_tikhonov_fitnessfunc(
+    output_dir, loader, params, dimensions, level2, nr_avg_runs=3)
 
-# TODO: add callback that saves checkpoints
 result = skopt.gp_minimize(
     n_calls=opt_steps,
     func=fitness,

--- a/experiments/sine/run.py
+++ b/experiments/sine/run.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import torch
@@ -7,6 +8,10 @@ import torsk
 from torsk.models import ESN
 from torsk.visualize import plot_mackey
 from torsk.data import SineDataset, SeqDataLoader
+from torsk import utils
+
+
+logging.basicConfig(level="INFO")
 
 
 # Parameters and model initialization
@@ -17,6 +22,13 @@ dataset = SineDataset(
     train_length=params.train_length,
     pred_length=params.pred_length)
 loader = iter(SeqDataLoader(dataset, batch_size=1, shuffle=True))
+
+
+model = ESN(params)
+inputs, train_labels, pred_labels, orig_data = next(loader)
+
+zero_state = torch.zeros(1, params.hidden_size)
+_, states = model(inputs, zero_state, states_only=True)
 
 predictions, labels = [], []
 for i in tqdm(range(30)):

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-import torsk
+import torsk.utils
 from torsk.models import ESN
 
 
@@ -30,7 +30,6 @@ def test_save_load(tmpdir):
     }
     """
     params_json = tmpdir.join("params.json")
-    model_pth = tmpdir.join("model.pth")
     with open(params_json, "w") as dst:
         dst.write(params_string)
 
@@ -41,9 +40,9 @@ def test_save_load(tmpdir):
 
     _, out1 = model(inputs, state)
 
-    torsk.save_model(model, str(model_pth))
+    torsk.utils.save_model(tmpdir, model)
 
-    model = torsk.load_model(str(tmpdir))
+    model = torsk.utils.load_model(str(tmpdir))
     _, out2 = model(inputs, state)
 
     assert np.all(out1.numpy() == out2.numpy())

--- a/torsk/__init__.py
+++ b/torsk/__init__.py
@@ -47,7 +47,7 @@ def mse(predictions, labels):
 
 
 def train_predict_esn(model, loader, params, outdir=None):
-    if not isinstance(outdir, pathlib.Path):
+    if outdir is not None and not isinstance(outdir, pathlib.Path):
         outdir = pathlib.Path(outdir)
 
     model.eval()  # because we are not using gradients

--- a/torsk/__init__.py
+++ b/torsk/__init__.py
@@ -60,12 +60,7 @@ def train_predict_esn(model, loader, params, outfile=None, modelfile=None):
         dump_states(outfile, states.squeeze().numpy())
 
     logger.debug("Optimizing output weights")
-    model.optimize(
-        inputs=inputs[tlen:],
-        states=states[tlen:],
-        labels=labels[tlen:],
-        method=params.train_method,
-        beta=params.tikhonov_beta)
+    model.optimize(inputs=inputs[tlen:], states=states[tlen:], labels=labels[tlen:])
     if modelfile is not None:
         logger.debug(f"Saving model to {modelfile}")
         save_model(model, modelfile)

--- a/torsk/hpopt.py
+++ b/torsk/hpopt.py
@@ -72,18 +72,18 @@ def optimize_wout(outdir, model, inputs, states, train_labels, pred_labels):
 
 
 def _evaluate_hyperparams(outdir, model, loader, level2_params_list):
-    logger.info(f"Dumping model at {outdir}")
+    logger.debug(f"Dumping model at {outdir}")
     utils.save_model(outdir, model, prefix="untrained")
 
-    logger.info("Loading dataset")
+    logger.debug("Loading dataset")
     inputs, labels, pred_labels, orig_data = next(loader)
 
-    logger.info(f"Creating {inputs.size(0)} training states")
+    logger.debug(f"Creating {inputs.size(0)} training states")
     states = utils.create_training_states(model, inputs)
 
     # TODO: save orig_data?
     train_data_nc = outdir / "train_data.nc"
-    logger.info(f"Dumping training data at {train_data_nc}")
+    logger.debug(f"Dumping training data at {train_data_nc}")
     utils.dump_training(
         fname=train_data_nc,
         inputs=inputs.reshape([-1, model.params.input_size]),
@@ -110,11 +110,11 @@ def evaluate_hyperparams(outdir, params, level2_params_list, loader, iters=1):
 
     for ii in range(1, iters + 1):
 
-        logger.info("Building model")
+        logger.debug("Building model")
         model = ESN(params)
 
         rundir = outdir.joinpath(f"run-{ii:03d}")
-        logger.info(f"Evaluation run: {rundir}")
+        logger.debug(f"Evaluation run: {rundir}")
 
         _evaluate_hyperparams(
             outdir=rundir, model=model, loader=loader,
@@ -149,6 +149,7 @@ def esn_tikhonov_fitnessfunc(outdir, loader, params, dimensions,
     def fitness(**sampled_params):
 
         params.update(sampled_params)
+        logger.info(f"Sampled params: {params}")
 
         subdir = utils.create_path(outdir, sampled_params)
 

--- a/torsk/hpopt.py
+++ b/torsk/hpopt.py
@@ -1,12 +1,116 @@
+import pathlib
 import logging
+
 import numpy as np
 from skopt.utils import use_named_args
 import torch
 from tqdm import tqdm
-from torsk.models import ESN
 
+from torsk.models import ESN
+from torsk import utils
 
 logger = logging.getLogger(__name__)
+
+
+SECOND_LEVEL_HYPERPARAMETERS = [
+    "sigma", "domain", "transient_length", "pred_length"
+]
+
+
+def is_second_level_param(param_name):
+    return param_name in SECOND_LEVEL_HYPERPARAMETERS
+
+
+def valid_second_level_params(params):
+    for name in params:
+        if not is_second_level_param(name):
+            return False
+    return True
+
+
+def evaluate_hyperparams(outdir, default_params, hyper_params, loader, tikhonov_betas):
+    if not isinstance(outdir, pathlib.Path):
+        outdir = pathlib.Path(outdir)
+    if not outdir.exists():
+        outdir.mkdir(parents=True)
+
+    logger.info("Building model")
+    model = ESN(default_params)
+
+    logger.info(f"Dumping model at {outdir}/[params.json, model.pth]")
+    utils.save_model(outdir, model)
+
+    logger.info("Loading dataset")
+    inputs, labels, pred_labels, orig_data = next(loader)
+
+    logger.info(f"Creating {inputs.size(0)} training states")
+    states = utils.create_training_states(model, inputs)
+
+    # TODO: save orig_data?
+    train_data_nc = outdir / "train_data.nc"
+    logger.info(f"Dumping training data at {train_data_nc}")
+    utils.dump_training(
+        fname=train_data_nc,
+        inputs=inputs.reshape([-1, model.params.input_size]),
+        labels=labels.reshape([-1, model.params.output_size]),
+        states=states.squeeze(),
+        pred_labels=pred_labels.reshape([-1, model.params.output_size]))
+
+    for hyper in hyper_params:
+        if valid_second_level_params(hyper):
+            model.params.update(hyper)
+            level2_outdir = utils.create_path(outdir, hyper)
+            optimize_wout(
+                outdir=level2_outdir, model=model, inputs=inputs,
+                states=states, train_labels=labels, pred_labels=pred_labels,
+                tikhonov_betas=tikhonov_betas)
+        else:
+            raise ValueError(
+                f"Not all hyper_params are of second level: {hyper_params}")
+
+
+def optimize_wout(outdir, model, inputs, states, train_labels, pred_labels, tikhonov_betas):
+    """Run optimization of last ESN layer (Wout) both with Pseudo Inverse and
+    Tikhonov with a list of regularization parameter values."""
+    if not isinstance(outdir, pathlib.Path):
+        outdir = pathlib.Path(outdir)
+
+    tlen = model.params.transient_length
+    plen = model.params.pred_length
+    init_input = train_labels[-1]
+    init_state = states[-1]
+
+    def _optimize(model, method, beta):
+        model.params.train_method = method
+        model.params.tikhonov_beta = beta
+        logger.info(f"Optimizing Wout with method:{method} / beta:{beta}")
+        model.optimize(
+            inputs=inputs[tlen:], states=states[tlen:], labels=train_labels[tlen:])
+
+        logger.info(f"Predicting {plen} steps")
+        outputs, out_states = model.predict(
+            init_input, init_state, nr_predictions=plen)
+
+        if method == "pinv":
+            method_outdir = outdir / "pinv"
+        elif method == "tikhonov":
+            method_outdir = outdir / f"tik{beta}"
+
+        pred_data_nc = method_outdir / "pred_data.nc"
+        logger.info(f"Dumping prediction data at {pred_data_nc}")
+        utils.dump_prediction(
+            fname=pred_data_nc,
+            outputs=outputs.reshape([-1, model.params.output_size]),
+            labels=pred_labels.reshape([-1, model.params.output_size]),
+            states=out_states.squeeze())
+
+        logger.info(f"Dumping model at {method_outdir}/[params.json, model.pth]")
+        utils.save_model(method_outdir, model)
+
+    _optimize(model, method="pinv", beta=None)
+
+    for beta in tikhonov_betas:
+        _optimize(model, method="tikhonov", beta=beta)
 
 
 def _tikhonov_optimize(tikhonov_betas, model, params, inputs, states, labels, pred_labels):

--- a/torsk/hpopt.py
+++ b/torsk/hpopt.py
@@ -12,9 +12,7 @@ from torsk import utils
 logger = logging.getLogger(__name__)
 
 
-SECOND_LEVEL_HYPERPARAMETERS = [
-    "sigma", "domain", "transient_length", "pred_length"
-]
+SECOND_LEVEL_HYPERPARAMETERS = ["transient_length", "pred_length"]
 
 
 def is_second_level_param(param_name):

--- a/torsk/hpopt.py
+++ b/torsk/hpopt.py
@@ -1,12 +1,9 @@
 import pathlib
 import logging
 
-import numpy as np
 import netCDF4 as nc
 import pandas as pd
 from skopt.utils import use_named_args
-import torch
-from tqdm import tqdm
 
 from torsk.models import ESN
 from torsk import utils
@@ -54,7 +51,7 @@ def optimize_wout(outdir, model, inputs, states, train_labels, pred_labels):
     init_state = states[-1]
 
     logger.debug(f"Optimizing Wout with method:{model.params.train_method}"
-                  " / beta:{mdoel.params.tikhonov_beta}")
+                 " / beta:{mdoel.params.tikhonov_beta}")
     model.optimize(
         inputs=inputs[tlen:], states=states[tlen:], labels=train_labels[tlen:])
 
@@ -124,35 +121,6 @@ def evaluate_hyperparams(outdir, params, level2_params_list, loader, iters=1):
             level2_params_list=level2_params_list)
 
 
-# def _tikhonov_optimize(tikhonov_betas, model, params, inputs, states, labels, pred_labels):
-#     """Find optimal regularization parameter beta out of a given list of tikhonov_betas.
-#     The generated states would be always the same for varying beta, so this can be
-#     run independently of the other hyper-parameter searches.
-#     """
-#     tlen = params.transient_length
-# 
-#     metrics = []
-#     for beta in tikhonov_betas:
-#         model.optimize(
-#             inputs=inputs[tlen:],
-#             states=states[tlen:],
-#             labels=labels[tlen:],
-#             method="tikhonov",
-#             beta=beta)
-# 
-#         init_inputs = labels[-1]
-#         outputs, _ = model.predict(
-#             init_inputs, states[-1], nr_predictions=params.pred_length)
-# 
-#         error = (outputs - pred_labels)**2
-#         metric = torch.mean(error).item()
-#         if not np.isfinite(metric):
-#             metric = 1e7
-#         metrics.append(metric)
-#     min_tik = np.argmin(metrics)
-#     return tikhonov_betas[min_tik], metrics[min_tik]
-
-
 def esn_tikhonov_fitnessfunc(outdir, loader, params, dimensions,
                              level2_params_list, nr_avg_runs=10):
     """Fitness function for hyper-parameter optimization that automatically
@@ -191,7 +159,7 @@ def esn_tikhonov_fitnessfunc(outdir, loader, params, dimensions,
         trained_model_dirs = get_hpopt_dirs(subdir)
         runs = []
         for model_dir in trained_model_dirs:
-            data = {"level2":model_dir.name}
+            data = {"level2": model_dir.name}
             data["metric"] = read_metric(model_dir)
             data["run"] = int(model_dir.parent.name.split("-")[-1])
             runs.append(data)

--- a/torsk/models/esn.py
+++ b/torsk/models/esn.py
@@ -34,7 +34,8 @@ def pseudo_inverse_lstsq(inputs, states, labels):
     condition  = s[0]/s[-1];
 
     if(log2(abs(condition)) > 12): # More than half of the bits in the data are lost
-        print("Large condition number in pseudoinverse:", condition," losing more than half of the digits. "
+        print("Large condition number in pseudoinverse:",
+              condition," losing more than half of the digits.",
               "Expect numerical blowup!");
         print("Largest and smallest singular values:",s[0],s[-1])
         
@@ -160,6 +161,7 @@ class ESN(nn.Module):
     """
     def __init__(self, params):
         super(ESN, self).__init__()
+        self.params = params
         if params.input_size != params.output_size:
             raise ValueError(
                 "Currently input and output dimensions must be the same.")
@@ -225,7 +227,7 @@ class ESN(nn.Module):
             states.append(state)
         return torch.stack(outputs, dim=0), torch.stack(states, dim=0)
 
-    def optimize(self, inputs, states, labels, method='pinv', beta=None):
+    def optimize(self, inputs, states, labels):
         """Train the output layer.
 
         Parameters
@@ -241,6 +243,9 @@ class ESN(nn.Module):
             inputs = inputs.reshape([-1, inputs.size(2)])
             states = states.reshape([-1, states.size(2)])
             labels = labels.reshape([-1, labels.size(2)])
+
+        method = self.params.train_method
+        beta = self.params.tikhonov_beta
 
         if method == 'tikhonov':
             if beta is None:

--- a/torsk/utils.py
+++ b/torsk/utils.py
@@ -5,7 +5,6 @@ import netCDF4 as nc
 import torch
 
 import torsk
-from torsk.models import ESN
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +48,8 @@ def save_model(modeldir, model, prefix=None):
 
 
 def load_model(modeldir, prefix=None):
+    # TODO: fix circular import
+    from torsk.models import ESN
     if isinstance(modeldir, str):
         modeldir = pathlib.Path(modeldir)
     prefix = _fix_prefix(prefix)

--- a/torsk/utils.py
+++ b/torsk/utils.py
@@ -1,0 +1,164 @@
+import logging
+import pathlib
+import numpy as np
+import netCDF4 as nc
+import torch
+
+import torsk
+from torsk.models import ESN
+
+logger = logging.getLogger(__name__)
+
+
+def create_training_states(model, inputs):
+    zero_state = torch.zeros(1, model.params.hidden_size)
+    _, states = model(inputs, zero_state, states_only=True)
+    return states
+
+
+def save_model(modeldir, model):
+    if not isinstance(modeldir, pathlib.Path):
+        modeldir = pathlib.Path(modeldir)
+    if not modeldir.exists():
+        modeldir.mkdir(parents=True)
+
+    model_pth = modeldir / "model.pth"
+    params_json = modeldir / "params.json"
+    state_dict = model.state_dict()
+
+    # convert sparse tensor
+    key = "esn_cell.weight_hh"
+    if isinstance(state_dict[key], torch.sparse.FloatTensor):
+        # TODO: can be removed when save/load is implemented for sparse tensors
+        # discussion: https://github.com/pytorch/pytorch/issues/9674
+        weight = state_dict.pop(key)
+        state_dict[key + "_indices"] = weight.coalesce().indices()
+        state_dict[key + "_values"] = weight.coalesce().values()
+
+    model.params.save(params_json.as_posix())
+    torch.save(state_dict, model_pth.as_posix())
+
+
+def load_model(modeldir):
+    if isinstance(modeldir, str):
+        modeldir = pathlib.Path(modeldir)
+
+    params = torsk.Params(modeldir / "params.json")
+    model = ESN(params)
+    state_dict = torch.load(modeldir / "model.pth")
+
+    # restore sparse tensor
+    key = "esn_cell.weight_hh"
+    key_idx = key + "_indices"
+    key_val = key + "_values"
+    if key_idx in state_dict:
+        # TODO: can be removed when save/load is implemented for sparse tensors
+        # discussion: https://github.com/pytorch/pytorch/issues/9674
+        weight_idx = state_dict.pop(key_idx)
+        weight_val = state_dict.pop(key_val)
+        hidden_size = params.hidden_size
+        weight_hh = torch.sparse.FloatTensor(
+            weight_idx, weight_val, [hidden_size, hidden_size])
+        state_dict[key] = weight_hh
+
+    model.load_state_dict(state_dict)
+
+    return model
+
+
+def dump_training(fname, inputs, labels, states, pred_labels, attrs=None):
+    if isinstance(inputs, torch.Tensor):
+        inputs = inputs.numpy()
+    if isinstance(labels, torch.Tensor):
+        labels = labels.numpy()
+    if isinstance(states, torch.Tensor):
+        states = states.numpy()
+    if isinstance(pred_labels, torch.Tensor):
+        pred_labels = pred_labels.numpy()
+
+    if not isinstance(fname, pathlib.Path):
+        fname = pathlib.Path(fname)
+    if not fname.parent.exists():
+        fname.parent.mkdir(parents=True)
+
+    with nc.Dataset(fname, "w") as dst:
+
+        dst.createDimension("train_length", inputs.shape[0])
+        dst.createDimension("pred_length", pred_labels.shape[0])
+        dst.createDimension("inputs_size", inputs.shape[1])
+        dst.createDimension("outputs_size", labels.shape[1])
+        dst.createDimension("hidden_size", states.shape[1])
+
+        dst.createVariable("inputs", float, ["train_length", "inputs_size"])
+        dst.createVariable("labels", float, ["train_length", "outputs_size"])
+        dst.createVariable("states", float, ["train_length", "hidden_size"])
+        dst.createVariable("pred_labels", float, ["pred_length", "outputs_size"])
+
+        if attrs is not None:
+            dst.setncatts(attrs)
+
+        dst["inputs"][:] = inputs
+        dst["labels"][:] = labels
+        dst["states"][:] = states
+        dst["pred_labels"][:] = pred_labels
+
+
+def dump_prediction(fname, outputs, labels, states, attrs=None):
+    if isinstance(outputs, torch.Tensor):
+        outputs = outputs.numpy()
+    if isinstance(labels, torch.Tensor):
+        labels = labels.numpy()
+    if isinstance(states, torch.Tensor):
+        states = states.numpy()
+
+    if not isinstance(fname, pathlib.Path):
+        fname = pathlib.Path(fname)
+    if not fname.parent.exists():
+        fname.parent.mkdir(parents=True)
+
+    error = (outputs - labels)**2
+    rmse = np.mean(error)**.5
+
+    with nc.Dataset(fname, "w") as dst:
+
+        dst.createDimension("pred_length", outputs.shape[0])
+        dst.createDimension("output_size", outputs.shape[1])
+        dst.createDimension("hidden_size", states.shape[1])
+        dst.createDimension("scalar", 1)
+
+        dst.createVariable("outputs", float, ["pred_length", "output_size"])
+        dst.createVariable("labels", float, ["pred_length", "output_size"])
+        dst.createVariable("states", float, ["pred_length", "hidden_size"])
+        dst.createVariable("rmse", float, ["scalar"])
+
+        if attrs is not None:
+            dst.setncatts(attrs)
+
+        dst["outputs"][:] = outputs
+        dst["labels"][:] = labels
+        dst["states"][:] = states
+        dst["rmse"][:] = rmse
+
+
+def create_path(root, param_dict, prefix='level2', postfix=None):
+    if not isinstance(root, pathlib.Path):
+        root = pathlib.Path(root)
+    folder = prefix
+    for key, val in param_dict.items():
+        folder += f"-{key}:{val}"
+    if postfix is not None:
+        folder += f"-{postfix}"
+    return root / folder
+
+
+def parse_path(path):
+    param_dict = {}
+    for string in path.name.split("-"):
+        if ":" in string:
+            key, val = string.split(":")
+            try:
+                val = eval(val)
+            except Exception:
+                pass
+            param_dict[key] = val
+    return param_dict


### PR DESCRIPTION
Trying to resolve #20 

The hyper-parameter optimization will create a folder structure parameter. If the hyper-params are `spectral_radius`, and `weight_init` it will look like this:

```
model-spectral_radius:1.5-weight_init:1.0/
     - params.json
     - model.pth
     - train_data.nc
     - run-domain:{domain}-transient_length:{transient_length}/
     - ...
```

After the __untrained__ `model.pth` has been created all following steps are deterministic as the only source of randomness is the creation of the model matrices.
The `train_data.nc` of the run folders will contain the used inputs/labels and created states which can now be generated.


Next the output layer can be optimized. For some (level-two) hyper-parameters the optimization of the states that are created by a given input sequence are invariant and can be reused. This is reflected in another sub directory of the folder structure:

```
run-transient_length:{transient_length}/
    - pinv/
    - tik{tikhonov_beta}
```

These subdirectories will contain `pinv` and `tik` folders. They contain the now __trained__ models and the corresponding predictions. Additionally, the `params.json` in which only the parameters defined in the parent paths are updated accordingly.
```
pinv/
    - pred_data.nc
    - model.pth
    - params.json
```